### PR TITLE
Track remote changes from upstream

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,11 @@
 language: php
 php:
-  - 5.3
-  - 5.4
-  - 5.5
   - 5.6
   - 7.0
   - hhvm
-  
-matrix:
-    allow_failures:
-        - php: hhvm
-        - php: 7.0
 env:
   - REDIS_STANDALONE=0
   - REDIS_STANDALONE=1
-  
 before_script:
   - sh -c "if [ $REDIS_STANDALONE -eq 0 ]; then wget https://github.com/nicolasff/phpredis/archive/2.2.3.zip -O php-redis.zip && unzip php-redis.zip; fi"
   - sh -c "if [ $REDIS_STANDALONE -eq 0 ]; then cd phpredis-2.2.3/ && phpize && ./configure && make && make install; fi"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,16 @@
 language: php
-php:
-  - 5.6
-  - 7.0
-  - hhvm
-env:
-  - REDIS_STANDALONE=0
-  - REDIS_STANDALONE=1
+matrix:
+  include:
+    - php: 5.6
+      env: ENABLE_REDIS_EXT=0
+    - php: 5.6
+      env: ENABLE_REDIS_EXT=1
+    - php: 7.0
+      env: ENABLE_REDIS_EXT=0
+    - php: 7.0
+      env: ENABLE_REDIS_EXT=1
+    - php: hhvm
+      env: ENABLE_REDIS_EXT=0
 before_script:
-  - sh -c "if [ $REDIS_STANDALONE -eq 0 ]; then wget https://github.com/nicolasff/phpredis/archive/2.2.3.zip -O php-redis.zip && unzip php-redis.zip; fi"
-  - sh -c "if [ $REDIS_STANDALONE -eq 0 ]; then cd phpredis-2.2.3/ && phpize && ./configure && make && make install; fi"
-  - sh -c "if [ $REDIS_STANDALONE -eq 0 ]; then echo \"extension=redis.so\" >> `php --ini | grep \"Loaded Configuration\" | sed -e \"s|.*:\s*||\"`; fi"
+  - sh -c "if [ $ENABLE_REDIS_EXT -eq 1 ]; then echo \"extension=redis.so\" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi"
   - composer install

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: php
 php:
   - 5.6
   - 7.0
+  - 7.1
   - hhvm
 matrix:
   exclude:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,15 @@
 language: php
+php:
+  - 5.6
+  - 7.0
+  - hhvm
 matrix:
-  include:
-    - php: 5.6
-      env: ENABLE_REDIS_EXT=0
-    - php: 5.6
-      env: ENABLE_REDIS_EXT=1
-    - php: 7.0
-      env: ENABLE_REDIS_EXT=0
-    - php: 7.0
-      env: ENABLE_REDIS_EXT=1
+  exclude:
     - php: hhvm
-      env: ENABLE_REDIS_EXT=0
+      env: ENABLE_REDIS_EXT=1
+env:
+  - ENABLE_REDIS_EXT=0
+  - ENABLE_REDIS_EXT=1
 before_script:
   - sh -c "if [ $ENABLE_REDIS_EXT -eq 1 ]; then echo \"extension=redis.so\" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi"
   - composer install

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ This method can be used to conveniently remove a job from a queue.
 Resque::dequeue('default', ['My_Job']);
 
 // Removes job class 'My_Job' with Job ID '087df5819a790ac666c9608e2234b21e' of queue 'default'
-Resuque::dequeue('default', ['My_Job' => '087df5819a790ac666c9608e2234b21e']);
+Resque::dequeue('default', ['My_Job' => '087df5819a790ac666c9608e2234b21e']);
 
 // Removes job class 'My_Job' with arguments of queue 'default'
 Resque::dequeue('default', ['My_Job' => array('foo' => 1, 'bar' => 2)]);

--- a/README.md
+++ b/README.md
@@ -53,11 +53,9 @@ If you're not familiar with Composer, please see <http://getcomposer.org/>.
 
 ```json
 {
-    // ...
     "require": {
-        "chrisboulton/php-resque": "1.2.x"	// Most recent tagged version
-    },
-    // ...
+        "chrisboulton/php-resque": "1.2.x"
+    }
 }
 ```
 

--- a/bin/resque
+++ b/bin/resque
@@ -96,7 +96,7 @@ if(!empty($PREFIX)) {
 if($count > 1) {
     for($i = 0; $i < $count; ++$i) {
         $pid = Resque::fork();
-        if($pid == -1) {
+        if($pid === false || pid === -1) {
             $logger->log(Psr\Log\LogLevel::EMERGENCY, 'Could not fork worker {count}', array('count' => $i));
             die();
         }

--- a/bin/resque
+++ b/bin/resque
@@ -96,7 +96,7 @@ if(!empty($PREFIX)) {
 if($count > 1) {
     for($i = 0; $i < $count; ++$i) {
         $pid = Resque::fork();
-        if($pid === false || pid === -1) {
+        if($pid === false || $pid === -1) {
             $logger->log(Psr\Log\LogLevel::EMERGENCY, 'Could not fork worker {count}', array('count' => $i));
             die();
         }

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
 	"require": {
 		"php": ">=5.3.0",
 		"ext-pcntl": "*",
-		"colinmollenhour/credis": "~1.2",
+		"colinmollenhour/credis": "~1.7",
 		"psr/log": "1.0.0"
 	},
 	"suggest": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
 		"php": ">=5.3.0",
 		"ext-pcntl": "*",
 		"colinmollenhour/credis": "~1.7",
-		"psr/log": "1.0.0"
+		"psr/log": "~1.0"
 	},
 	"suggest": {
 		"ext-proctitle": "Allows php-resque to rename the title of UNIX processes to show the status of a worker.",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
 		"ext-redis": "Native PHP extension for Redis connectivity. Credis will automatically utilize when available."
 	},
 	"require-dev": {
-		"phpunit/phpunit": "3.7.*"
+		"phpunit/phpunit": "~4.1"
 	},
 	"bin": [
 		"bin/resque"

--- a/composer.json
+++ b/composer.json
@@ -1,20 +1,14 @@
 {
-	"name": "chrisboulton/php-resque",
+	"name": "mcfedr/php-resque",
 	"type": "library",
 	"description": "Redis backed library for creating background jobs and processing them later. Based on resque for Ruby.",
 	"keywords": ["job", "background", "redis", "resque"],
-	"homepage": "http://www.github.com/chrisboulton/php-resque/",
+	"homepage": "http://www.github.com/mcfedr/php-resque/",
 	"license": "MIT",
 	"authors": [
 		{
 			"name": "Chris Boulton",
 			"email": "chris@bigcommerce.com"
-		}
-	],
-	"repositories": [
-		{
-			"type": "vcs",
-			"url": "https://github.com/chrisboulton/credis"
 		}
 	],
 	"require": {

--- a/composer.lock
+++ b/composer.lock
@@ -1,33 +1,35 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "1862fac0c6f40ddf7d98bcef5f4bbd77",
+    "hash": "41124ffd15a15b52947e430b92b8f10f",
+    "content-hash": "11906622d4e017ff6807c6dff51f208d",
     "packages": [
         {
             "name": "colinmollenhour/credis",
-            "version": "1.4",
+            "version": "1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/colinmollenhour/credis.git",
-                "reference": "2079564c61cc49867eddc3cc918c711564164d65"
+                "reference": "74b2b703da5c58dc07fb97e8954bc63280b469bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/colinmollenhour/credis/zipball/2079564c61cc49867eddc3cc918c711564164d65",
-                "reference": "2079564c61cc49867eddc3cc918c711564164d65",
+                "url": "https://api.github.com/repos/colinmollenhour/credis/zipball/74b2b703da5c58dc07fb97e8954bc63280b469bf",
+                "reference": "74b2b703da5c58dc07fb97e8954bc63280b469bf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": ">=5.4.0"
             },
             "type": "library",
             "autoload": {
                 "classmap": [
                     "Client.php",
-                    "Cluster.php"
+                    "Cluster.php",
+                    "Sentinel.php"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -42,7 +44,7 @@
             ],
             "description": "Credis is a lightweight interface to the Redis key-value store which wraps the phpredis library when available for better performance.",
             "homepage": "https://github.com/colinmollenhour/credis",
-            "time": "2014-05-05 19:31:30"
+            "time": "2016-03-24 15:50:52"
         },
         {
             "name": "psr/log",
@@ -86,23 +88,23 @@
     "packages-dev": [
         {
             "name": "phpunit/php-code-coverage",
-            "version": "1.2.17",
+            "version": "1.2.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "6ef2bf3a1c47eca07ea95f0d8a902a6340390b34"
+                "reference": "fe2466802556d3fe4e4d1d58ffd3ccfd0a19be0b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/6ef2bf3a1c47eca07ea95f0d8a902a6340390b34",
-                "reference": "6ef2bf3a1c47eca07ea95f0d8a902a6340390b34",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/fe2466802556d3fe4e4d1d58ffd3ccfd0a19be0b",
+                "reference": "fe2466802556d3fe4e4d1d58ffd3ccfd0a19be0b",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3",
                 "phpunit/php-file-iterator": ">=1.3.0@stable",
                 "phpunit/php-text-template": ">=1.2.0@stable",
-                "phpunit/php-token-stream": ">=1.1.3@stable"
+                "phpunit/php-token-stream": ">=1.1.3,<1.3.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "3.7.*@dev"
@@ -143,35 +145,37 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2014-03-28 10:53:45"
+            "time": "2014-09-02 10:13:14"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.3.4",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "acd690379117b042d1c8af1fafd61bde001bf6bb"
+                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/acd690379117b042d1c8af1fafd61bde001bf6bb",
-                "reference": "acd690379117b042d1c8af1fafd61bde001bf6bb",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
+                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4.x-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
-                    "File/"
+                    "src/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
-            "include-path": [
-                ""
-            ],
             "license": [
                 "BSD-3-Clause"
             ],
@@ -188,20 +192,20 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2013-10-10 15:34:57"
+            "time": "2015-06-21 13:08:43"
         },
         {
             "name": "phpunit/php-text-template",
-            "version": "1.2.0",
+            "version": "1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "206dfefc0ffe9cebf65c413e3d0e809c82fbf00a"
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/206dfefc0ffe9cebf65c413e3d0e809c82fbf00a",
-                "reference": "206dfefc0ffe9cebf65c413e3d0e809c82fbf00a",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
                 "shasum": ""
             },
             "require": {
@@ -210,20 +214,17 @@
             "type": "library",
             "autoload": {
                 "classmap": [
-                    "Text/"
+                    "src/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
-            "include-path": [
-                ""
-            ],
             "license": [
                 "BSD-3-Clause"
             ],
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -232,35 +233,35 @@
             "keywords": [
                 "template"
             ],
-            "time": "2014-01-30 17:20:04"
+            "time": "2015-06-21 13:50:34"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "1.0.5",
+            "version": "1.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "19689d4354b295ee3d8c54b4f42c3efb69cbc17c"
+                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/19689d4354b295ee3d8c54b4f42c3efb69cbc17c",
-                "reference": "19689d4354b295ee3d8c54b4f42c3efb69cbc17c",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/38e9124049cf1a164f1e4537caf19c99bf1eb260",
+                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
             },
+            "require-dev": {
+                "phpunit/phpunit": "~4|~5"
+            },
             "type": "library",
             "autoload": {
                 "classmap": [
-                    "PHP/"
+                    "src/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
-            "include-path": [
-                ""
-            ],
             "license": [
                 "BSD-3-Clause"
             ],
@@ -276,7 +277,7 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2013-08-02 07:42:54"
+            "time": "2016-05-12 18:03:57"
         },
         {
             "name": "phpunit/php-token-stream",
@@ -330,16 +331,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "3.7.37",
+            "version": "3.7.38",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "ae6cefd7cc84586a5ef27e04bae11ee940ec63dc"
+                "reference": "38709dc22d519a3d1be46849868aa2ddf822bcf6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/ae6cefd7cc84586a5ef27e04bae11ee940ec63dc",
-                "reference": "ae6cefd7cc84586a5ef27e04bae11ee940ec63dc",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/38709dc22d519a3d1be46849868aa2ddf822bcf6",
+                "reference": "38709dc22d519a3d1be46849868aa2ddf822bcf6",
                 "shasum": ""
             },
             "require": {
@@ -399,7 +400,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2014-04-30 12:24:19"
+            "time": "2014-10-17 09:04:17"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -452,32 +453,34 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v2.5.0",
-            "target-dir": "Symfony/Component/Yaml",
+            "version": "v2.8.12",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/Yaml.git",
-                "reference": "b4b09c68ec2f2727574544ef0173684281a5033c"
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "e7540734bad981fe59f8ef14b6fc194ae9df8d9c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Yaml/zipball/b4b09c68ec2f2727574544ef0173684281a5033c",
-                "reference": "b4b09c68ec2f2727574544ef0173684281a5033c",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/e7540734bad981fe59f8ef14b6fc194ae9df8d9c",
+                "reference": "e7540734bad981fe59f8ef14b6fc194ae9df8d9c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=5.3.9"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.5-dev"
+                    "dev-master": "2.8-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
+                "psr-4": {
                     "Symfony\\Component\\Yaml\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -486,32 +489,26 @@
             "authors": [
                 {
                     "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com",
-                    "homepage": "http://fabien.potencier.org",
-                    "role": "Lead Developer"
+                    "email": "fabien@symfony.com"
                 },
                 {
                     "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "Symfony Yaml Component",
-            "homepage": "http://symfony.com",
-            "time": "2014-05-16 14:25:18"
+            "homepage": "https://symfony.com",
+            "time": "2016-09-02 01:57:56"
         }
     ],
-    "aliases": [
-
-    ],
+    "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [
-
-    ],
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
     "platform": {
         "php": ">=5.3.0",
         "ext-pcntl": "*"
     },
-    "platform-dev": [
-
-    ]
+    "platform-dev": []
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "41124ffd15a15b52947e430b92b8f10f",
-    "content-hash": "11906622d4e017ff6807c6dff51f208d",
+    "content-hash": "f0f5d69a575587f5dbcd0c9985c8cc51",
     "packages": [
         {
             "name": "colinmollenhour/credis",
-            "version": "1.7",
+            "version": "1.8.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/colinmollenhour/credis.git",
-                "reference": "74b2b703da5c58dc07fb97e8954bc63280b469bf"
+                "reference": "9c14b4bb0779127638a17dd8aab8f05f28c6df43"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/colinmollenhour/credis/zipball/74b2b703da5c58dc07fb97e8954bc63280b469bf",
-                "reference": "74b2b703da5c58dc07fb97e8954bc63280b469bf",
+                "url": "https://api.github.com/repos/colinmollenhour/credis/zipball/9c14b4bb0779127638a17dd8aab8f05f28c6df43",
+                "reference": "9c14b4bb0779127638a17dd8aab8f05f28c6df43",
                 "shasum": ""
             },
             "require": {
@@ -29,7 +28,8 @@
                 "classmap": [
                     "Client.php",
                     "Cluster.php",
-                    "Sentinel.php"
+                    "Sentinel.php",
+                    "Module.php"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -44,26 +44,34 @@
             ],
             "description": "Credis is a lightweight interface to the Redis key-value store which wraps the phpredis library when available for better performance.",
             "homepage": "https://github.com/colinmollenhour/credis",
-            "time": "2016-03-24 15:50:52"
+            "time": "2017-07-05T15:32:38+00:00"
         },
         {
             "name": "psr/log",
-            "version": "1.0.0",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "fe0936ee26643249e916849d48e3a51d5f5e278b"
+                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/fe0936ee26643249e916849d48e3a51d5f5e278b",
-                "reference": "fe0936ee26643249e916849d48e3a51d5f5e278b",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
+                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
                 "shasum": ""
             },
+            "require": {
+                "php": ">=5.3.0"
+            },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
             "autoload": {
-                "psr-0": {
-                    "Psr\\Log\\": ""
+                "psr-4": {
+                    "Psr\\Log\\": "Psr/Log/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -77,57 +85,322 @@
                 }
             ],
             "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
             "keywords": [
                 "log",
                 "psr",
                 "psr-3"
             ],
-            "time": "2012-12-21 11:40:51"
+            "time": "2016-10-10T12:19:37+00:00"
         }
     ],
     "packages-dev": [
         {
-            "name": "phpunit/php-code-coverage",
-            "version": "1.2.18",
+            "name": "doctrine/instantiator",
+            "version": "1.0.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "fe2466802556d3fe4e4d1d58ffd3ccfd0a19be0b"
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/fe2466802556d3fe4e4d1d58ffd3ccfd0a19be0b",
-                "reference": "fe2466802556d3fe4e4d1d58ffd3ccfd0a19be0b",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/8e884e78f9f0eb1329e445619e04456e64d8051d",
+                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "phpunit/php-file-iterator": ">=1.3.0@stable",
-                "phpunit/php-text-template": ">=1.2.0@stable",
-                "phpunit/php-token-stream": ">=1.1.3,<1.3.0"
+                "php": ">=5.3,<8.0-DEV"
             },
             "require-dev": {
-                "phpunit/phpunit": "3.7.*@dev"
-            },
-            "suggest": {
-                "ext-dom": "*",
-                "ext-xdebug": ">=2.0.5"
+                "athletic/athletic": "~0.1.8",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpunit/phpunit": "~4.0",
+                "squizlabs/php_codesniffer": "~2.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2.x-dev"
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "http://ocramius.github.com/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://github.com/doctrine/instantiator",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "time": "2015-06-14T21:17:01+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-common",
+            "version": "1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
+                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
+            "homepage": "http://www.phpdoc.org",
+            "keywords": [
+                "FQSEN",
+                "phpDocumentor",
+                "phpdoc",
+                "reflection",
+                "static analysis"
+            ],
+            "time": "2015-12-27T11:43:31+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-docblock",
+            "version": "3.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "86e24012a3139b42a7b71155cfaa325389f00f1f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/86e24012a3139b42a7b71155cfaa325389f00f1f",
+                "reference": "86e24012a3139b42a7b71155cfaa325389f00f1f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0",
+                "phpdocumentor/reflection-common": "^1.0@dev",
+                "phpdocumentor/type-resolver": "^0.4.0",
+                "webmozart/assert": "^1.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^0.9.4",
+                "phpunit/phpunit": "^4.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "time": "2017-08-29T19:37:41+00:00"
+        },
+        {
+            "name": "phpdocumentor/type-resolver",
+            "version": "0.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/9c977708995954784726e25d0cd1dddf4e65b0f7",
+                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5 || ^7.0",
+                "phpdocumentor/reflection-common": "^1.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^0.9.4",
+                "phpunit/phpunit": "^5.2||^4.8.24"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "time": "2017-07-14T14:27:02+00:00"
+        },
+        {
+            "name": "phpspec/prophecy",
+            "version": "v1.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpspec/prophecy.git",
+                "reference": "93d39f1f7f9326d746203c7c056f300f7f126073"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/93d39f1f7f9326d746203c7c056f300f7f126073",
+                "reference": "93d39f1f7f9326d746203c7c056f300f7f126073",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.0.2",
+                "php": "^5.3|^7.0",
+                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2",
+                "sebastian/comparator": "^1.1|^2.0",
+                "sebastian/recursion-context": "^1.0|^2.0|^3.0"
+            },
+            "require-dev": {
+                "phpspec/phpspec": "^2.5|^3.2",
+                "phpunit/phpunit": "^4.8 || ^5.6.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Prophecy\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Konstantin Kudryashov",
+                    "email": "ever.zet@gmail.com",
+                    "homepage": "http://everzet.com"
+                },
+                {
+                    "name": "Marcello Duarte",
+                    "email": "marcello.duarte@gmail.com"
+                }
+            ],
+            "description": "Highly opinionated mocking framework for PHP 5.3+",
+            "homepage": "https://github.com/phpspec/prophecy",
+            "keywords": [
+                "Double",
+                "Dummy",
+                "fake",
+                "mock",
+                "spy",
+                "stub"
+            ],
+            "time": "2017-03-02T20:05:34+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "2.2.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "eabf68b476ac7d0f73793aada060f1c1a9bf8979"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/eabf68b476ac7d0f73793aada060f1c1a9bf8979",
+                "reference": "eabf68b476ac7d0f73793aada060f1c1a9bf8979",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "phpunit/php-file-iterator": "~1.3",
+                "phpunit/php-text-template": "~1.2",
+                "phpunit/php-token-stream": "~1.3",
+                "sebastian/environment": "^1.3.2",
+                "sebastian/version": "~1.0"
+            },
+            "require-dev": {
+                "ext-xdebug": ">=2.1.4",
+                "phpunit/phpunit": "~4"
+            },
+            "suggest": {
+                "ext-dom": "*",
+                "ext-xdebug": ">=2.2.1",
+                "ext-xmlwriter": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.2.x-dev"
                 }
             },
             "autoload": {
                 "classmap": [
-                    "PHP/"
+                    "src/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
-            "include-path": [
-                ""
-            ],
             "license": [
                 "BSD-3-Clause"
             ],
@@ -145,20 +418,20 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2014-09-02 10:13:14"
+            "time": "2015-10-06T15:47:00+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.1",
+            "version": "1.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0"
+                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
-                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
+                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
                 "shasum": ""
             },
             "require": {
@@ -192,7 +465,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2015-06-21 13:08:43"
+            "time": "2016-10-03T07:40:28+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -233,29 +506,34 @@
             "keywords": [
                 "template"
             ],
-            "time": "2015-06-21 13:50:34"
+            "time": "2015-06-21T13:50:34+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "1.0.8",
+            "version": "1.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260"
+                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/38e9124049cf1a164f1e4537caf19c99bf1eb260",
-                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
+                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^5.3.3 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4|~5"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -277,49 +555,48 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2016-05-12 18:03:57"
+            "time": "2017-02-26T11:10:40+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "1.2.2",
+            "version": "1.4.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "ad4e1e23ae01b483c16f600ff1bebec184588e32"
+                "reference": "e03f8f67534427a787e21a385a67ec3ca6978ea7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/ad4e1e23ae01b483c16f600ff1bebec184588e32",
-                "reference": "ad4e1e23ae01b483c16f600ff1bebec184588e32",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/e03f8f67534427a787e21a385a67ec3ca6978ea7",
+                "reference": "e03f8f67534427a787e21a385a67ec3ca6978ea7",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
                 "php": ">=5.3.3"
             },
+            "require-dev": {
+                "phpunit/phpunit": "~4.2"
+            },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2-dev"
+                    "dev-master": "1.4-dev"
                 }
             },
             "autoload": {
                 "classmap": [
-                    "PHP/"
+                    "src/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
-            "include-path": [
-                ""
-            ],
             "license": [
                 "BSD-3-Clause"
             ],
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
-                    "role": "lead"
+                    "email": "sebastian@phpunit.de"
                 }
             ],
             "description": "Wrapper around PHP's tokenizer extension.",
@@ -327,62 +604,61 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2014-03-03 05:10:30"
+            "time": "2017-02-27T10:12:30+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "3.7.38",
+            "version": "4.8.36",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "38709dc22d519a3d1be46849868aa2ddf822bcf6"
+                "reference": "46023de9a91eec7dfb06cc56cb4e260017298517"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/38709dc22d519a3d1be46849868aa2ddf822bcf6",
-                "reference": "38709dc22d519a3d1be46849868aa2ddf822bcf6",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/46023de9a91eec7dfb06cc56cb4e260017298517",
+                "reference": "46023de9a91eec7dfb06cc56cb4e260017298517",
                 "shasum": ""
             },
             "require": {
-                "ext-ctype": "*",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-pcre": "*",
                 "ext-reflection": "*",
                 "ext-spl": "*",
                 "php": ">=5.3.3",
-                "phpunit/php-code-coverage": "~1.2",
-                "phpunit/php-file-iterator": "~1.3",
-                "phpunit/php-text-template": "~1.1",
-                "phpunit/php-timer": "~1.0",
-                "phpunit/phpunit-mock-objects": "~1.2",
-                "symfony/yaml": "~2.0"
-            },
-            "require-dev": {
-                "pear-pear.php.net/pear": "1.9.4"
+                "phpspec/prophecy": "^1.3.1",
+                "phpunit/php-code-coverage": "~2.1",
+                "phpunit/php-file-iterator": "~1.4",
+                "phpunit/php-text-template": "~1.2",
+                "phpunit/php-timer": "^1.0.6",
+                "phpunit/phpunit-mock-objects": "~2.3",
+                "sebastian/comparator": "~1.2.2",
+                "sebastian/diff": "~1.2",
+                "sebastian/environment": "~1.3",
+                "sebastian/exporter": "~1.2",
+                "sebastian/global-state": "~1.0",
+                "sebastian/version": "~1.0",
+                "symfony/yaml": "~2.1|~3.0"
             },
             "suggest": {
                 "phpunit/php-invoker": "~1.1"
             },
             "bin": [
-                "composer/bin/phpunit"
+                "phpunit"
             ],
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.7.x-dev"
+                    "dev-master": "4.8.x-dev"
                 }
             },
             "autoload": {
                 "classmap": [
-                    "PHPUnit/"
+                    "src/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
-            "include-path": [
-                "",
-                "../../symfony/yaml/"
-            ],
             "license": [
                 "BSD-3-Clause"
             ],
@@ -394,45 +670,52 @@
                 }
             ],
             "description": "The PHP Unit Testing framework.",
-            "homepage": "http://www.phpunit.de/",
+            "homepage": "https://phpunit.de/",
             "keywords": [
                 "phpunit",
                 "testing",
                 "xunit"
             ],
-            "time": "2014-10-17 09:04:17"
+            "time": "2017-06-21T08:07:12+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "1.2.3",
+            "version": "2.3.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "5794e3c5c5ba0fb037b11d8151add2a07fa82875"
+                "reference": "ac8e7a3db35738d56ee9a76e78a4e03d97628983"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/5794e3c5c5ba0fb037b11d8151add2a07fa82875",
-                "reference": "5794e3c5c5ba0fb037b11d8151add2a07fa82875",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/ac8e7a3db35738d56ee9a76e78a4e03d97628983",
+                "reference": "ac8e7a3db35738d56ee9a76e78a4e03d97628983",
                 "shasum": ""
             },
             "require": {
+                "doctrine/instantiator": "^1.0.2",
                 "php": ">=5.3.3",
-                "phpunit/php-text-template": ">=1.1.1@stable"
+                "phpunit/php-text-template": "~1.2",
+                "sebastian/exporter": "~1.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.4"
             },
             "suggest": {
                 "ext-soap": "*"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3.x-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
-                    "PHPUnit/"
+                    "src/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
-            "include-path": [
-                ""
-            ],
             "license": [
                 "BSD-3-Clause"
             ],
@@ -449,29 +732,407 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2013-01-13 10:24:48"
+            "time": "2015-10-02T06:51:40+00:00"
         },
         {
-            "name": "symfony/yaml",
-            "version": "v2.8.12",
+            "name": "sebastian/comparator",
+            "version": "1.2.4",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/yaml.git",
-                "reference": "e7540734bad981fe59f8ef14b6fc194ae9df8d9c"
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/e7540734bad981fe59f8ef14b6fc194ae9df8d9c",
-                "reference": "e7540734bad981fe59f8ef14b6fc194ae9df8d9c",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
+                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.9"
+                "php": ">=5.3.3",
+                "sebastian/diff": "~1.2",
+                "sebastian/exporter": "~1.2 || ~2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.8-dev"
+                    "dev-master": "1.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "http://www.github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "time": "2017-01-29T09:50:25+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "1.4.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/7f066a26a962dbe58ddea9f72a4e82874a3975a4",
+                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff"
+            ],
+            "time": "2017-05-22T07:24:03+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "1.3.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/be2c607e43ce4c89ecd60e75c6a85c126e754aea",
+                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8 || ^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "time": "2016-08-18T05:49:44+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "1.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/42c4c2eec485ee3e159ec9884f95b431287edde4",
+                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "sebastian/recursion-context": "~1.0"
+            },
+            "require-dev": {
+                "ext-mbstring": "*",
+                "phpunit/phpunit": "~4.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "http://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "time": "2016-06-17T09:04:28+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bc37d50fea7d017d3d340f230811c9f1d7280af4",
+                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.2"
+            },
+            "suggest": {
+                "ext-uopz": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "time": "2015-10-12T03:26:01+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "1.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "b19cc3298482a335a95f3016d2f8a6950f0fbcd7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/b19cc3298482a335a95f3016d2f8a6950f0fbcd7",
+                "reference": "b19cc3298482a335a95f3016d2f8a6950f0fbcd7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "time": "2016-10-03T07:41:43+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "1.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
+                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "time": "2015-06-21T13:59:46+00:00"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v3.3.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "1d8c2a99c80862bdc3af94c1781bf70f86bccac0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/1d8c2a99c80862bdc3af94c1781bf70f86bccac0",
+                "reference": "1d8c2a99c80862bdc3af94c1781bf70f86bccac0",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8"
+            },
+            "require-dev": {
+                "symfony/console": "~2.8|~3.0"
+            },
+            "suggest": {
+                "symfony/console": "For validating YAML files using the lint command"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.3-dev"
                 }
             },
             "autoload": {
@@ -498,7 +1159,57 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2016-09-02 01:57:56"
+            "time": "2017-07-29T21:54:42+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/assert.git",
+                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/2db61e59ff05fe5126d152bd0655c9ea113e550f",
+                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6",
+                "sebastian/version": "^1.0.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "time": "2016-11-23T20:04:58+00:00"
         }
     ],
     "aliases": [],

--- a/demo/queue.php
+++ b/demo/queue.php
@@ -13,6 +13,10 @@ $args = array(
 		'test' => 'test',
 	),
 );
+if (empty($argv[2])) {
+	$jobId = Resque::enqueue('default', $argv[1], $args, true);
+} else {
+        $jobId = Resque::enqueue($argv[1], $argv[2], $args, true);	
+}
 
-$jobId = Resque::enqueue($argv[1], $argv[2], $args, true);
 echo "Queued job ".$jobId."\n\n";

--- a/lib/Resque.php
+++ b/lib/Resque.php
@@ -101,8 +101,12 @@ class Resque
 	 */
 	public static function push($queue, $item)
 	{
+		$encodedItem = json_encode($item);
+		if ($encodedItem === false) {
+			return false;
+		}
 		self::redis()->sadd('queues', $queue);
-		$length = self::redis()->rpush('queue:' . $queue, json_encode($item));
+		$length = self::redis()->rpush('queue:' . $queue, $encodedItem);
 		if ($length < 1) {
 			return false;
 		}

--- a/lib/Resque.php
+++ b/lib/Resque.php
@@ -72,12 +72,12 @@ class Resque
 	 *
 	 * Will close connection to Redis before forking.
 	 *
-	 * @return int Return vars as per pcntl_fork()
+	 * @return int Return vars as per pcntl_fork(). False if pcntl_fork is unavailable
 	 */
 	public static function fork()
 	{
 		if(!function_exists('pcntl_fork')) {
-			return -1;
+			return false;
 		}
 
 		// Close the connection to Redis before forking.
@@ -281,12 +281,12 @@ class Resque
 		$originalQueue = 'queue:'. $queue;
 		$tempQueue = $originalQueue. ':temp:'. time();
 		$requeueQueue = $tempQueue. ':requeue';
-		
+
 		// move each item from original queue to temp queue and process it
 		$finished = false;
 		while (!$finished) {
 			$string = self::redis()->rpoplpush($originalQueue, self::redis()->getPrefix() . $tempQueue);
-	
+
 			if (!empty($string)) {
 				if(self::matchItem($string, $items)) {
 					self::redis()->rpop($tempQueue);
@@ -311,7 +311,7 @@ class Resque
 		// remove temp queue and requeue queue
 		self::redis()->del($requeueQueue);
 		self::redis()->del($tempQueue);
-		
+
 		return $counter;
 	}
 
@@ -377,4 +377,3 @@ class Resque
 		return md5(uniqid('', true));
 	}
 }
-

--- a/lib/Resque/Job.php
+++ b/lib/Resque/Job.php
@@ -28,10 +28,10 @@ class Resque_Job implements Resque_JobInterface
 	 */
 	private $instance;
 
-    /**
-     * @var Resque_Job_FactoryInterface
-     */
-    private $jobFactory;
+	/**
+	 * @var Resque_Job_FactoryInterface
+	 */
+	private $jobFactory;
 
 	/**
 	 * Instantiate a new instance of a job.
@@ -45,18 +45,18 @@ class Resque_Job implements Resque_JobInterface
 		$this->payload = $payload;
 	}
 
-    /**
-     * Create a new job and save it to the specified queue.
-     *
-     * @param string $queue The name of the queue to place the job in.
-     * @param string $class The name of the class that contains the code to execute the job.
-     * @param array $args Any optional arguments that should be passed when the job is executed.
-     * @param boolean $monitor Set to true to be able to monitor the status of a job.
-     * @param string $id Unique identifier for tracking the job. Generated if not supplied.
-     *
-     * @return string
-     * @throws \InvalidArgumentException
-     */
+	/**
+	 * Create a new job and save it to the specified queue.
+	 *
+	 * @param string $queue The name of the queue to place the job in.
+	 * @param string $class The name of the class that contains the code to execute the job.
+	 * @param array $args Any optional arguments that should be passed when the job is executed.
+	 * @param boolean $monitor Set to true to be able to monitor the status of a job.
+	 * @param string $id Unique identifier for tracking the job. Generated if not supplied.
+	 *
+	 * @return string
+	 * @throws \InvalidArgumentException
+	 */
 	public static function create($queue, $class, $args = null, $monitor = false, $id = null)
 	{
 		if (is_null($id)) {
@@ -82,41 +82,41 @@ class Resque_Job implements Resque_JobInterface
 		return $id;
 	}
 
-    /**
-     * Find the next available job from the specified queue and return an
-     * instance of Resque_Job for it.
-     *
-     * @param string $queue The name of the queue to check for a job in.
-     * @return false|object Null when there aren't any waiting jobs, instance of Resque_Job when a job was found.
-     */
-    public static function reserve($queue)
-    {
-        $payload = Resque::pop($queue);
-        if(!is_array($payload)) {
-            return false;
-        }
+	/**
+	 * Find the next available job from the specified queue and return an
+	 * instance of Resque_Job for it.
+	 *
+	 * @param string $queue The name of the queue to check for a job in.
+	 * @return false|object Null when there aren't any waiting jobs, instance of Resque_Job when a job was found.
+	 */
+	public static function reserve($queue)
+	{
+		$payload = Resque::pop($queue);
+		if(!is_array($payload)) {
+			return false;
+		}
 
-        return new Resque_Job($queue, $payload);
-    }
+		return new Resque_Job($queue, $payload);
+	}
 
-    /**
-     * Find the next available job from the specified queues using blocking list pop
-     * and return an instance of Resque_Job for it.
-     *
-     * @param array             $queues
-     * @param int               $timeout
-     * @return false|object Null when there aren't any waiting jobs, instance of Resque_Job when a job was found.
-     */
-    public static function reserveBlocking(array $queues, $timeout = null)
-    {
-        $item = Resque::blpop($queues, $timeout);
+	/**
+	 * Find the next available job from the specified queues using blocking list pop
+	 * and return an instance of Resque_Job for it.
+	 *
+	 * @param array             $queues
+	 * @param int               $timeout
+	 * @return false|object Null when there aren't any waiting jobs, instance of Resque_Job when a job was found.
+	 */
+	public static function reserveBlocking(array $queues, $timeout = null)
+	{
+		$item = Resque::blpop($queues, $timeout);
 
-        if(!is_array($item)) {
-            return false;
-        }
+		if(!is_array($item)) {
+			return false;
+		}
 
-        return new Resque_Job($item['queue'], $item['payload']);
-    }
+		return new Resque_Job($item['queue'], $item['payload']);
+	}
 
 	/**
 	 * Update the status of the current job.
@@ -158,11 +158,11 @@ class Resque_Job implements Resque_JobInterface
 		return $this->payload['args'][0];
 	}
 
-    /**
-     * Get the instantiated object for this job that will be performing work.
-     * @return Resque_JobInterface Instance of the object that this job belongs to.
-     * @throws Resque_Exception
-     */
+	/**
+	 * Get the instantiated object for this job that will be performing work.
+	 * @return Resque_JobInterface Instance of the object that this job belongs to.
+	 * @throws Resque_Exception
+	 */
 	public function getInstance()
 	{
 		if (!is_null($this->instance)) {
@@ -181,14 +181,14 @@ class Resque_Job implements Resque_JobInterface
 			);
 		}
 
-        if ($this->jobFactory !== null) {
-            $this->instance = $this->jobFactory->create($this->payload['class'], $this->getArguments(), $this->queue);
-            return $this->instance;
-        }
-        $this->instance = new $this->payload['class'];
-        $this->instance->job = $this;
-        $this->instance->args = $this->getArguments();
-        $this->instance->queue = $this->queue;
+		if ($this->jobFactory !== null) {
+			$this->instance = $this->jobFactory->create($this->payload['class'], $this->getArguments(), $this->queue);
+			return $this->instance;
+		}
+		$this->instance = new $this->payload['class'];
+		$this->instance->job = $this;
+		$this->instance->args = $this->getArguments();
+		$this->instance->queue = $this->queue;
 
 		return $this->instance;
 	}
@@ -284,14 +284,14 @@ class Resque_Job implements Resque_JobInterface
 		return '(' . implode(' | ', $name) . ')';
 	}
 
-    /**
-     * @param Resque_Job_FactoryInterface $jobFactory
-     * @return Resque_Job
-     */
-    public function setJobFactory(Resque_Job_FactoryInterface $jobFactory)
-    {
-        $this->jobFactory = $jobFactory;
+	/**
+	 * @param Resque_Job_FactoryInterface $jobFactory
+	 * @return Resque_Job
+	 */
+	public function setJobFactory(Resque_Job_FactoryInterface $jobFactory)
+	{
+		$this->jobFactory = $jobFactory;
 
-        return $this;
-    }
+		return $this;
+	}
 }

--- a/lib/Resque/Job.php
+++ b/lib/Resque/Job.php
@@ -182,13 +182,14 @@ class Resque_Job implements Resque_JobInterface
 		}
 
         if ($this->jobFactory !== null) {
-            $this->instance = $this->jobFactory->create($this->payload['class']);
-        } else {
-            $this->instance = new $this->payload['class'];
+            $this->instance = $this->jobFactory->create($this->payload['class'], $this->getArguments(), $this->queue);
+            return $this->instance;
         }
-		$this->instance->job = $this;
-		$this->instance->args = $this->getArguments();
-		$this->instance->queue = $this->queue;
+        $this->instance = new $this->payload['class'];
+        $this->instance->job = $this;
+        $this->instance->args = $this->getArguments();
+        $this->instance->queue = $this->queue;
+
 		return $this->instance;
 	}
 

--- a/lib/Resque/Job.php
+++ b/lib/Resque/Job.php
@@ -182,7 +182,7 @@ class Resque_Job implements Resque_JobInterface
 		}
 
         if ($this->jobFactory !== null) {
-            $this->instance = $this->jobFactory->create();
+            $this->instance = $this->jobFactory->create($this->payload['class']);
         } else {
             $this->instance = new $this->payload['class'];
         }

--- a/lib/Resque/Job/Factory.php
+++ b/lib/Resque/Job/Factory.php
@@ -1,0 +1,32 @@
+<?php
+
+class Resque_Job_Factory implements Resque_Job_FactoryInterface
+{
+
+    /**
+     * @param $className
+     * @param array $args
+     * @param $queue
+     * @return Resque_JobInterface
+     * @throws \Resque_Exception
+     */
+    public function create($className, $args, $queue)
+    {
+        if (!class_exists($className)) {
+            throw new Resque_Exception(
+                'Could not find job class ' . $className . '.'
+            );
+        }
+
+        if (!method_exists($className, 'perform')) {
+            throw new Resque_Exception(
+                'Job class ' . $className . ' does not contain a perform method.'
+            );
+        }
+
+        $instance = new $className;
+        $instance->args = $args;
+        $instance->queue = $queue;
+        return $instance;
+    }
+}

--- a/lib/Resque/Job/FactoryInterface.php
+++ b/lib/Resque/Job/FactoryInterface.php
@@ -3,7 +3,8 @@
 interface Resque_Job_FactoryInterface
 {
     /**
+     * @param $className
      * @return Resque_JobInterface
      */
-    public function create();
+    public function create($className);
 }

--- a/lib/Resque/Job/FactoryInterface.php
+++ b/lib/Resque/Job/FactoryInterface.php
@@ -8,5 +8,5 @@ interface Resque_Job_FactoryInterface
 	 * @param $queue
 	 * @return Resque_JobInterface
 	 */
-	public function create($className, array $args, $queue);
+	public function create($className, $args, $queue);
 }

--- a/lib/Resque/Job/FactoryInterface.php
+++ b/lib/Resque/Job/FactoryInterface.php
@@ -2,11 +2,11 @@
 
 interface Resque_Job_FactoryInterface
 {
-    /**
-     * @param $className
-     * @param array $args
-     * @param $queue
-     * @return Resque_JobInterface
-     */
-    public function create($className, array $args, $queue);
+	/**
+	 * @param $className
+	 * @param array $args
+	 * @param $queue
+	 * @return Resque_JobInterface
+	 */
+	public function create($className, array $args, $queue);
 }

--- a/lib/Resque/Job/FactoryInterface.php
+++ b/lib/Resque/Job/FactoryInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+interface Resque_Job_FactoryInterface
+{
+    /**
+     * @return Resque_JobInterface
+     */
+    public function create();
+}

--- a/lib/Resque/Job/FactoryInterface.php
+++ b/lib/Resque/Job/FactoryInterface.php
@@ -4,7 +4,9 @@ interface Resque_Job_FactoryInterface
 {
     /**
      * @param $className
+     * @param array $args
+     * @param $queue
      * @return Resque_JobInterface
      */
-    public function create($className);
+    public function create($className, array $args, $queue);
 }

--- a/lib/Resque/Job/Status.php
+++ b/lib/Resque/Job/Status.php
@@ -90,10 +90,11 @@ class Resque_Job_Status
 			return;
 		}
 
-		$statusPacket = array(
-			'status' => $status,
-			'updated' => time(),
-		);
+		$statusPacket = json_decode(Resque::redis()->get((string)$this), true);
+
+		$statusPacket['status'] = $status;
+		$statusPacket['updated'] = time();
+
 		Resque::redis()->set((string)$this, json_encode($statusPacket));
 
 		// Expire the status for completed jobs after 24 hours

--- a/lib/Resque/JobInterface.php
+++ b/lib/Resque/JobInterface.php
@@ -2,8 +2,8 @@
 
 interface Resque_JobInterface
 {
-    /**
-     * @return bool
-     */
-    public function perform();
+	/**
+	 * @return bool
+	 */
+	public function perform();
 }

--- a/lib/Resque/JobInterface.php
+++ b/lib/Resque/JobInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+interface Resque_JobInterface
+{
+    /**
+     * @return bool
+     */
+    public function perform();
+}

--- a/lib/Resque/Redis.php
+++ b/lib/Resque/Redis.php
@@ -148,6 +148,7 @@ class Resque_Redis
 	 * - host:port
 	 * - redis://user:pass@host:port/db?option1=val1&option2=val2
 	 * - tcp://user:pass@host:port/db?option1=val1&option2=val2
+	 * - unix:///path/to/redis.sock
 	 *
 	 * Note: the 'user' part of the DSN is not used.
 	 *
@@ -160,6 +161,16 @@ class Resque_Redis
 		if ($dsn == '') {
 			// Use a sensible default for an empty DNS string
 			$dsn = 'redis://' . self::DEFAULT_HOST;
+		}
+		if(substr($dsn, 0, 7) === 'unix://') {
+			return array(
+				$dsn,
+				null,
+				null,
+				null,
+				null,
+				null,
+			);
 		}
 		$parts = parse_url($dsn);
 

--- a/lib/Resque/Redis.php
+++ b/lib/Resque/Redis.php
@@ -98,7 +98,7 @@ class Resque_Redis
 	 */
 	public static function prefix($namespace)
 	{
-	    if (substr($namespace, -1) !== ':' and $namespace != '') {
+	    if (substr($namespace, -1) !== ':' && $namespace != '') {
 	        $namespace .= ':';
 	    }
 	    self::$defaultNamespace = $namespace;

--- a/lib/Resque/Redis.php
+++ b/lib/Resque/Redis.php
@@ -98,7 +98,7 @@ class Resque_Redis
 	 */
 	public static function prefix($namespace)
 	{
-	    if (substr($namespace, -1) !== ':') {
+	    if (substr($namespace, -1) !== ':' and $namespace != '') {
 	        $namespace .= ':';
 	    }
 	    self::$defaultNamespace = $namespace;

--- a/lib/Resque/Redis.php
+++ b/lib/Resque/Redis.php
@@ -142,7 +142,7 @@ class Resque_Redis
 			}
 		}
 		catch(CredisException $e) {
-			throw new Resque_RedisException($e);
+			throw new Resque_RedisException('Error communicating with Redis: ' . $e->getMessage(), 0, $e);
 		}
 	}
 
@@ -245,7 +245,7 @@ class Resque_Redis
 			return $this->driver->__call($name, $args);
 		}
 		catch (CredisException $e) {
-			throw new Resque_RedisException($e);
+			throw new Resque_RedisException('Error communicating with Redis: ' . $e->getMessage(), 0, $e);
 		}
 	}
 

--- a/lib/Resque/Redis.php
+++ b/lib/Resque/Redis.php
@@ -108,12 +108,16 @@ class Resque_Redis
 	 * @param string|array $server A DSN or array
 	 * @param int $database A database number to select. However, if we find a valid database number in the DSN the
 	 *                      DSN-supplied value will be used instead and this parameter is ignored.
+	 * @param object $client Optional Credis_Cluster or Credis_Client instance instantiated by you
 	 */
-    public function __construct($server, $database = null)
+    public function __construct($server, $database = null, $client = null)
 	{
 		try {
 			if (is_array($server)) {
 				$this->driver = new Credis_Cluster($server);
+			}
+			else if (is_object($client)) {
+				$this->driver = $client;
 			}
 			else {
 				list($host, $port, $dsnDatabase, $user, $password, $options) = self::parseDsn($server);

--- a/lib/Resque/Redis.php
+++ b/lib/Resque/Redis.php
@@ -111,34 +111,38 @@ class Resque_Redis
 	 */
     public function __construct($server, $database = null)
 	{
-		if (is_array($server)) {
-			$this->driver = new Credis_Cluster($server);
-		}
-		else {
+		try {
+			if (is_array($server)) {
+				$this->driver = new Credis_Cluster($server);
+			}
+			else {
+				list($host, $port, $dsnDatabase, $user, $password, $options) = self::parseDsn($server);
+				// $user is not used, only $password
 
-			list($host, $port, $dsnDatabase, $user, $password, $options) = self::parseDsn($server);
-			// $user is not used, only $password
+				// Look for known Credis_Client options
+				$timeout = isset($options['timeout']) ? intval($options['timeout']) : null;
+				$persistent = isset($options['persistent']) ? $options['persistent'] : '';
+				$maxRetries = isset($options['max_connect_retries']) ? $options['max_connect_retries'] : 0;
 
-			// Look for known Credis_Client options
-			$timeout = isset($options['timeout']) ? intval($options['timeout']) : null;
-			$persistent = isset($options['persistent']) ? $options['persistent'] : '';
-			$maxRetries = isset($options['max_connect_retries']) ? $options['max_connect_retries'] : 0;
+				$this->driver = new Credis_Client($host, $port, $timeout, $persistent);
+				$this->driver->setMaxConnectRetries($maxRetries);
+				if ($password){
+					$this->driver->auth($password);
+				}
 
-			$this->driver = new Credis_Client($host, $port, $timeout, $persistent);
-			$this->driver->setMaxConnectRetries($maxRetries);
-			if ($password){
-				$this->driver->auth($password);
+				// If we have found a database in our DSN, use it instead of the `$database`
+				// value passed into the constructor.
+				if ($dsnDatabase !== false) {
+					$database = $dsnDatabase;
+				}
 			}
 
-			// If we have found a database in our DSN, use it instead of the `$database`
-			// value passed into the constructor.
-			if ($dsnDatabase !== false) {
-				$database = $dsnDatabase;
+			if ($database !== null) {
+				$this->driver->select($database);
 			}
 		}
-
-		if ($database !== null) {
-			$this->driver->select($database);
+		catch(CredisException $e) {
+			throw new Resque_RedisException($e);
 		}
 	}
 
@@ -241,7 +245,7 @@ class Resque_Redis
 			return $this->driver->__call($name, $args);
 		}
 		catch (CredisException $e) {
-			return false;
+			throw new Resque_RedisException($e);
 		}
 	}
 

--- a/lib/Resque/Redis.php
+++ b/lib/Resque/Redis.php
@@ -166,7 +166,7 @@ class Resque_Redis
 			return array(
 				$dsn,
 				null,
-				null,
+				false,
 				null,
 				null,
 				null,

--- a/lib/Resque/RedisException.php
+++ b/lib/Resque/RedisException.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Redis related exceptions
+ *
+ * @package		Resque
+ * @author		Chris Boulton <chris@bigcommerce.com>
+ * @license		http://www.opensource.org/licenses/mit-license.php
+ */
+class Resque_RedisException extends Resque_Exception
+{
+}
+?>

--- a/lib/Resque/Worker.php
+++ b/lib/Resque/Worker.php
@@ -69,13 +69,8 @@ class Resque_Worker
         }
 
         $this->queues = $queues;
-        if(function_exists('gethostname')) {
-            $hostname = gethostname();
-        }
-        else {
-            $hostname = php_uname('n');
-        }
-        $this->hostname = $hostname;
+        $this->hostname = php_uname('n');
+
         $this->id = $this->hostname . ':'.getmypid() . ':' . implode(',', $this->queues);
     }
 

--- a/lib/Resque/Worker.php
+++ b/lib/Resque/Worker.php
@@ -241,7 +241,7 @@ class Resque_Worker
 			$job->perform();
 		}
 		catch(Exception $e) {
-			$this->logger->log(Psr\Log\LogLevel::CRITICAL, '{job} has failed {stack}', array('job' => $job, 'stack' => (string)$e));
+			$this->logger->log(Psr\Log\LogLevel::CRITICAL, '{job} has failed {stack}', array('job' => $job, 'stack' => $e));
 			$job->fail($e);
 			return;
 		}

--- a/lib/Resque/Worker.php
+++ b/lib/Resque/Worker.php
@@ -241,7 +241,7 @@ class Resque_Worker
 			$job->perform();
 		}
 		catch(Exception $e) {
-			$this->logger->log(Psr\Log\LogLevel::CRITICAL, '{job} has failed {stack}', array('job' => $job, 'stack' => (string)$e);
+			$this->logger->log(Psr\Log\LogLevel::CRITICAL, '{job} has failed {stack}', array('job' => $job, 'stack' => (string)$e));
 			$job->fail($e);
 			return;
 		}

--- a/lib/Resque/Worker.php
+++ b/lib/Resque/Worker.php
@@ -241,7 +241,7 @@ class Resque_Worker
 			$job->perform();
 		}
 		catch(Exception $e) {
-			$this->logger->log(Psr\Log\LogLevel::CRITICAL, '{job} has failed {stack}', array('job' => $job, 'stack' => $e->getMessage()));
+g			$this->logger->log(Psr\Log\LogLevel::CRITICAL, '{job} has failed {stack}', array('job' => $job, 'stack' => (string)$e);
 			$job->fail($e);
 			return;
 		}

--- a/lib/Resque/Worker.php
+++ b/lib/Resque/Worker.php
@@ -241,7 +241,7 @@ class Resque_Worker
 			$job->perform();
 		}
 		catch(Exception $e) {
-g			$this->logger->log(Psr\Log\LogLevel::CRITICAL, '{job} has failed {stack}', array('job' => $job, 'stack' => (string)$e);
+			$this->logger->log(Psr\Log\LogLevel::CRITICAL, '{job} has failed {stack}', array('job' => $job, 'stack' => (string)$e);
 			$job->fail($e);
 			return;
 		}

--- a/lib/Resque/Worker.php
+++ b/lib/Resque/Worker.php
@@ -325,7 +325,7 @@ class Resque_Worker
 	{
 		$processTitle = 'resque-' . Resque::VERSION . ': ' . $status;
 		if(function_exists('cli_set_process_title') && PHP_OS !== 'Darwin') {
-			cli_set_process_title($processTitle);
+			@cli_set_process_title($processTitle);
 		}
 		else if(function_exists('setproctitle')) {
 			setproctitle($processTitle);

--- a/lib/Resque/Worker.php
+++ b/lib/Resque/Worker.php
@@ -325,7 +325,7 @@ class Resque_Worker
 	{
 		$processTitle = 'resque-' . Resque::VERSION . ': ' . $status;
 		if(function_exists('cli_set_process_title') && PHP_OS !== 'Darwin') {
-			@cli_set_process_title($processTitle);
+			cli_set_process_title($processTitle);
 		}
 		else if(function_exists('setproctitle')) {
 			setproctitle($processTitle);

--- a/test/Resque/Tests/EventTest.php
+++ b/test/Resque/Tests/EventTest.php
@@ -31,7 +31,7 @@ class Resque_Tests_EventTest extends Resque_Tests_TestCase
 		$payload = array(
 			'class' => 'Test_Job',
 			'args' => array(
-				'somevar',
+				array('somevar'),
 			),
 		);
 		$job = new Resque_Job('jobs', $payload);

--- a/test/Resque/Tests/JobTest.php
+++ b/test/Resque/Tests/JobTest.php
@@ -31,7 +31,15 @@ class Resque_Tests_JobTest extends Resque_Tests_TestCase
 	 */
 	public function testRedisErrorThrowsExceptionOnJobCreation()
 	{
-		Resque::setBackend('redis://255.255.255.255:1234');
+		$mockCredis = $this->getMockBuilder('Credis_Client')
+			->setMethods(['connect', '__call'])
+			->getMock();
+		$mockCredis->expects($this->any())->method('__call')
+			->will($this->throwException(new CredisException('failure')));
+
+		Resque::setBackend(function($database) use ($mockCredis) {
+			return new Resque_Redis('localhost:6379', $database, $mockCredis);
+		});
 		Resque::enqueue('jobs', 'This is a test');
 	}
 

--- a/test/Resque/Tests/JobTest.php
+++ b/test/Resque/Tests/JobTest.php
@@ -365,30 +365,30 @@ class Resque_Tests_JobTest extends Resque_Tests_TestCase
 	public function testUseFactoryToGetJobInstance()
     {
         $payload = array(
-            'class' => Some_Job_Class::class,
+            'class' => 'Some_Job_Class',
             'args' => null
         );
         $job = new Resque_Job('jobs', $payload);
-        $factory = $this->getMock(Resque_Job_FactoryInterface::class);
+        $factory = $this->getMock('Resque_Job_FactoryInterface');
         $job->setJobFactory($factory);
-        $testJob = $this->getMock(Resque_JobInterface::class);
+        $testJob = $this->getMock('Resque_JobInterface');
         $factory->expects(self::once())->method('create')->will($this->returnValue($testJob));
         $instance = $job->getInstance();
-        $this->assertInstanceOf(Resque_JobInterface::class, $instance);
+        $this->assertInstanceOf('Resque_JobInterface', $instance);
     }
 
     public function testDoNotUseFactoryToGetInstance()
     {
         $payload = array(
-            'class' => Some_Job_Class::class,
+            'class' => 'Some_Job_Class',
             'args' => null
         );
         $job = new Resque_Job('jobs', $payload);
-        $factory = $this->getMock(Resque_Job_FactoryInterface::class);
-        $testJob = $this->getMock(Resque_JobInterface::class);
+        $factory = $this->getMock('Resque_Job_FactoryInterface');
+        $testJob = $this->getMock('Resque_JobInterface');
         $factory->expects(self::never())->method('create')->will(self::returnValue($testJob));
         $instance = $job->getInstance();
-        $this->assertInstanceOf(Resque_JobInterface::class, $instance);
+        $this->assertInstanceOf('Resque_JobInterface', $instance);
     }
 }
 

--- a/test/Resque/Tests/JobTest.php
+++ b/test/Resque/Tests/JobTest.php
@@ -183,16 +183,16 @@ class Resque_Tests_JobTest extends Resque_Tests_TestCase
 
 	public function testJobWithNamespace()
 	{
-	    Resque_Redis::prefix('php');
-	    $queue = 'jobs';
-	    $payload = array('another_value');
-        Resque::enqueue($queue, 'Test_Job_With_TearDown', $payload);
-        
-        $this->assertEquals(Resque::queues(), array('jobs'));
-        $this->assertEquals(Resque::size($queue), 1);
+		Resque_Redis::prefix('php');
+		$queue = 'jobs';
+		$payload = array('another_value');
+		Resque::enqueue($queue, 'Test_Job_With_TearDown', $payload);
 
-        Resque_Redis::prefix('resque');
-        $this->assertEquals(Resque::size($queue), 0);        
+		$this->assertEquals(Resque::queues(), array('jobs'));
+		$this->assertEquals(Resque::size($queue), 1);
+
+		Resque_Redis::prefix('resque');
+		$this->assertEquals(Resque::size($queue), 0);
 	}
 
 	public function testDequeueAll()
@@ -363,56 +363,56 @@ class Resque_Tests_JobTest extends Resque_Tests_TestCase
 	}
 
 	public function testUseFactoryToGetJobInstance()
-    {
-        $payload = array(
-            'class' => 'Some_Job_Class',
-            'args' => null
-        );
-        $job = new Resque_Job('jobs', $payload);
-        $factory = new Some_Stub_Factory();
-        $job->setJobFactory($factory);
-        $instance = $job->getInstance();
-        $this->assertInstanceOf('Resque_JobInterface', $instance);
-    }
+	{
+		$payload = array(
+			'class' => 'Some_Job_Class',
+			'args' => null
+		);
+		$job = new Resque_Job('jobs', $payload);
+		$factory = new Some_Stub_Factory();
+		$job->setJobFactory($factory);
+		$instance = $job->getInstance();
+		$this->assertInstanceOf('Resque_JobInterface', $instance);
+	}
 
-    public function testDoNotUseFactoryToGetInstance()
-    {
-        $payload = array(
-            'class' => 'Some_Job_Class',
-            'args' => null
-        );
-        $job = new Resque_Job('jobs', $payload);
-        $factory = $this->getMock('Resque_Job_FactoryInterface');
-        $testJob = $this->getMock('Resque_JobInterface');
-        $factory->expects(self::never())->method('create')->will(self::returnValue($testJob));
-        $instance = $job->getInstance();
-        $this->assertInstanceOf('Resque_JobInterface', $instance);
-    }
+	public function testDoNotUseFactoryToGetInstance()
+	{
+		$payload = array(
+			'class' => 'Some_Job_Class',
+			'args' => null
+		);
+		$job = new Resque_Job('jobs', $payload);
+		$factory = $this->getMock('Resque_Job_FactoryInterface');
+		$testJob = $this->getMock('Resque_JobInterface');
+		$factory->expects(self::never())->method('create')->will(self::returnValue($testJob));
+		$instance = $job->getInstance();
+		$this->assertInstanceOf('Resque_JobInterface', $instance);
+	}
 }
 
 class Some_Job_Class implements Resque_JobInterface
 {
 
-    /**
-     * @return bool
-     */
-    public function perform()
-    {
-        return true;
-    }
+	/**
+	 * @return bool
+	 */
+	public function perform()
+	{
+		return true;
+	}
 }
 
 class Some_Stub_Factory implements Resque_Job_FactoryInterface
 {
 
-    /**
-     * @param $className
-     * @param array $args
-     * @param $queue
-     * @return Resque_JobInterface
-     */
-    public function create($className, array $args, $queue)
-    {
-        return new Some_Job_Class();
-    }
+	/**
+	 * @param $className
+	 * @param array $args
+	 * @param $queue
+	 * @return Resque_JobInterface
+	 */
+	public function create($className, array $args, $queue)
+	{
+		return new Some_Job_Class();
+	}
 }

--- a/test/Resque/Tests/JobTest.php
+++ b/test/Resque/Tests/JobTest.php
@@ -362,11 +362,22 @@ class Resque_Tests_JobTest extends Resque_Tests_TestCase
 		$this->assertEquals(Resque::size($queue), 2);
 	}
 
-	public function testUseFactoryToGetJobInstance()
+	public function testUseDefaultFactoryToGetJobInstance()
 	{
 		$payload = array(
 			'class' => 'Some_Job_Class',
 			'args' => null
+		);
+		$job = new Resque_Job('jobs', $payload);
+		$instance = $job->getInstance();
+		$this->assertInstanceOf('Some_Job_Class', $instance);
+	}
+
+	public function testUseFactoryToGetJobInstance()
+	{
+		$payload = array(
+			'class' => 'Some_Job_Class',
+			'args' => array(array())
 		);
 		$job = new Resque_Job('jobs', $payload);
 		$factory = new Some_Stub_Factory();
@@ -379,7 +390,7 @@ class Resque_Tests_JobTest extends Resque_Tests_TestCase
 	{
 		$payload = array(
 			'class' => 'Some_Job_Class',
-			'args' => null
+			'args' => array(array())
 		);
 		$job = new Resque_Job('jobs', $payload);
 		$factory = $this->getMock('Resque_Job_FactoryInterface');
@@ -411,7 +422,7 @@ class Some_Stub_Factory implements Resque_Job_FactoryInterface
 	 * @param $queue
 	 * @return Resque_JobInterface
 	 */
-	public function create($className, array $args, $queue)
+	public function create($className, $args, $queue)
 	{
 		return new Some_Job_Class();
 	}

--- a/test/Resque/Tests/JobTest.php
+++ b/test/Resque/Tests/JobTest.php
@@ -369,10 +369,8 @@ class Resque_Tests_JobTest extends Resque_Tests_TestCase
             'args' => null
         );
         $job = new Resque_Job('jobs', $payload);
-        $factory = $this->getMock('Resque_Job_FactoryInterface');
+        $factory = new Some_Stub_Factory();
         $job->setJobFactory($factory);
-        $testJob = $this->getMock('Resque_JobInterface');
-        $factory->expects(self::once())->method('create')->will($this->returnValue($testJob));
         $instance = $job->getInstance();
         $this->assertInstanceOf('Resque_JobInterface', $instance);
     }
@@ -401,5 +399,20 @@ class Some_Job_Class implements Resque_JobInterface
     public function perform()
     {
         return true;
+    }
+}
+
+class Some_Stub_Factory implements Resque_Job_FactoryInterface
+{
+
+    /**
+     * @param $className
+     * @param array $args
+     * @param $queue
+     * @return Resque_JobInterface
+     */
+    public function create($className, array $args, $queue)
+    {
+        return new Some_Job_Class();
     }
 }

--- a/test/Resque/Tests/JobTest.php
+++ b/test/Resque/Tests/JobTest.php
@@ -362,4 +362,44 @@ class Resque_Tests_JobTest extends Resque_Tests_TestCase
 		$this->assertEquals(Resque::size($queue), 2);
 	}
 
+	public function testUseFactoryToGetJobInstance()
+    {
+        $payload = array(
+            'class' => Some_Job_Class::class,
+            'args' => null
+        );
+        $job = new Resque_Job('jobs', $payload);
+        $factory = $this->getMock(Resque_Job_FactoryInterface::class);
+        $job->setJobFactory($factory);
+        $testJob = $this->getMock(Resque_JobInterface::class);
+        $factory->expects(self::once())->method('create')->will($this->returnValue($testJob));
+        $instance = $job->getInstance();
+        $this->assertInstanceOf(Resque_JobInterface::class, $instance);
+    }
+
+    public function testDoNotUseFactoryToGetInstance()
+    {
+        $payload = array(
+            'class' => Some_Job_Class::class,
+            'args' => null
+        );
+        $job = new Resque_Job('jobs', $payload);
+        $factory = $this->getMock(Resque_Job_FactoryInterface::class);
+        $testJob = $this->getMock(Resque_JobInterface::class);
+        $factory->expects(self::never())->method('create')->will(self::returnValue($testJob));
+        $instance = $job->getInstance();
+        $this->assertInstanceOf(Resque_JobInterface::class, $instance);
+    }
+}
+
+class Some_Job_Class implements Resque_JobInterface
+{
+
+    /**
+     * @return bool
+     */
+    public function perform()
+    {
+        return true;
+    }
 }

--- a/test/Resque/Tests/JobTest.php
+++ b/test/Resque/Tests/JobTest.php
@@ -26,6 +26,15 @@ class Resque_Tests_JobTest extends Resque_Tests_TestCase
 		$this->assertTrue((bool)Resque::enqueue('jobs', 'Test_Job'));
 	}
 
+	/**
+	 * @expectedException Resque_RedisException
+	 */
+	public function testRedisErrorThrowsExceptionOnJobCreation()
+	{
+		Resque::setBackend('redis://255.255.255.255:1234');
+		Resque::enqueue('jobs', 'This is a test');
+	}
+
 	public function testQeueuedJobCanBeReserved()
 	{
 		Resque::enqueue('jobs', 'Test_Job');

--- a/test/Resque/Tests/RedisTest.php
+++ b/test/Resque/Tests/RedisTest.php
@@ -1,13 +1,21 @@
 <?php
 /**
- * Resque_Redis DSN tests.
+ * Resque_Event tests.
  *
  * @package		Resque/Tests
- * @author		Iskandar Najmuddin <github@iskandar.co.uk>
+ * @author		Chris Boulton <chris@bigcommerce.com>
  * @license		http://www.opensource.org/licenses/mit-license.php
  */
-class Resque_Tests_DsnTest extends Resque_Tests_TestCase
+class Resque_Tests_RedisTest extends Resque_Tests_TestCase
 {
+	/**
+	 * @expectedException Resque_RedisException
+	 */
+	public function testRedisExceptionsAreSurfaced()
+	{
+		$redis = new Resque_Redis('redis://255.255.255.255:1234');
+		$redis->ping();
+	}
 
 	/**
 	 * These DNS strings are considered valid.
@@ -178,5 +186,4 @@ class Resque_Tests_DsnTest extends Resque_Tests_TestCase
 		// The next line should throw an InvalidArgumentException
 		$result = Resque_Redis::parseDsn($dsn);
 	}
-
 }

--- a/test/Resque/Tests/RedisTest.php
+++ b/test/Resque/Tests/RedisTest.php
@@ -13,8 +13,16 @@ class Resque_Tests_RedisTest extends Resque_Tests_TestCase
 	 */
 	public function testRedisExceptionsAreSurfaced()
 	{
-		$redis = new Resque_Redis('redis://255.255.255.255:1234');
-		$redis->ping();
+		$mockCredis = $this->getMockBuilder('Credis_Client')
+			->setMethods(['connect', '__call'])
+			->getMock();
+		$mockCredis->expects($this->any())->method('__call')
+			->will($this->throwException(new CredisException('failure')));
+
+		Resque::setBackend(function($database) use ($mockCredis) {
+			return new Resque_Redis('localhost:6379', $database, $mockCredis);
+		});
+		Resque::redis()->ping();
 	}
 
 	/**

--- a/test/Resque/Tests/TestCase.php
+++ b/test/Resque/Tests/TestCase.php
@@ -11,6 +11,11 @@ class Resque_Tests_TestCase extends PHPUnit_Framework_TestCase
 	protected $resque;
 	protected $redis;
 
+    public static function setUpBeforeClass()
+    {
+        date_default_timezone_set('UTC');
+    }
+
 	public function setUp()
 	{
 		$config = file_get_contents(REDIS_CONF);

--- a/test/Resque/Tests/TestCase.php
+++ b/test/Resque/Tests/TestCase.php
@@ -22,6 +22,8 @@ class Resque_Tests_TestCase extends PHPUnit_Framework_TestCase
 		preg_match('#^\s*port\s+([0-9]+)#m', $config, $matches);
 		$this->redis = new Credis_Client('localhost', $matches[1]);
 
+		Resque::setBackend('redis://localhost:' . $matches[1]);
+
 		// Flush redis
 		$this->redis->flushAll();
 	}

--- a/test/Resque/Tests/TestCase.php
+++ b/test/Resque/Tests/TestCase.php
@@ -11,10 +11,10 @@ class Resque_Tests_TestCase extends PHPUnit_Framework_TestCase
 	protected $resque;
 	protected $redis;
 
-    public static function setUpBeforeClass()
-    {
-        date_default_timezone_set('UTC');
-    }
+	public static function setUpBeforeClass()
+	{
+		date_default_timezone_set('UTC');
+	}
 
 	public function setUp()
 	{


### PR DESCRIPTION
I'd like to konw if [these changes](https://github.com/chrisboulton/php-resque/compare/master...phansys:track-upstream?expand=1) was proposed at the base of this fork: `chrisboulton/php-resque`, since it could be a lot easier to leverage the evolution of that library without the overhead of tracking the changes. Further when these changes are very slight.